### PR TITLE
Adjust Azure route matching

### DIFF
--- a/azure/azure.go
+++ b/azure/azure.go
@@ -128,29 +128,39 @@ func WithAPIKey(apiKey string) option.RequestOption {
 
 // jsonRoutes have JSON payloads - we'll deserialize looking for a .model field in there
 // so we won't have to worry about individual types for completions vs embeddings, etc...
-var jsonRoutes = map[string]bool{
-	"/openai/completions":        true,
-	"/openai/chat/completions":   true,
-	"/openai/embeddings":         true,
-	"/openai/audio/speech":       true,
-	"/openai/images/generations": true,
+var jsonRoutes = []string{
+	"/openai/completions",
+	"/openai/chat/completions",
+	"/openai/embeddings",
+	"/openai/audio/speech",
+	"/openai/images/generations",
 }
 
 // audioMultipartRoutes have mime/multipart payloads. These are less generic - we're very much
 // expecting a transcription or translation payload for these.
-var audioMultipartRoutes = map[string]bool{
-	"/openai/audio/transcriptions": true,
-	"/openai/audio/translations":   true,
+var audioMultipartRoutes = []string{
+	"/openai/audio/transcriptions",
+	"/openai/audio/translations",
+}
+
+func pathMatchesRoute(path string, routes []string) bool {
+	for _, route := range routes {
+		if strings.HasSuffix(path, route) {
+			return true
+		}
+	}
+	return false
 }
 
 // getReplacementPathWithDeployment parses the request body to extract out the Model parameter (or equivalent)
 // (note, the req.Body is fully read as part of this, and is replaced with a bytes.Reader)
 func getReplacementPathWithDeployment(req *http.Request) (string, error) {
-	if jsonRoutes[req.URL.Path] {
+
+	if pathMatchesRoute(req.URL.Path, jsonRoutes) {
 		return getJSONRoute(req)
 	}
 
-	if audioMultipartRoutes[req.URL.Path] {
+	if pathMatchesRoute(req.URL.Path, audioMultipartRoutes) {
 		return getAudioMultipartRoute(req)
 	}
 

--- a/azure/azure_test.go
+++ b/azure/azure_test.go
@@ -115,3 +115,32 @@ func TestNoRouteChangeNeeded(t *testing.T) {
 		t.Fatalf("replacementpath didn't match: %s", replacementPath)
 	}
 }
+
+func TestJSONRouteWithPrefix(t *testing.T) {
+	chatCompletionParams := openai.ChatCompletionNewParams{
+		Model: openai.ChatModel("arbitraryDeployment"),
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.AssistantMessage("You are a helpful assistant"),
+			openai.UserMessage("Can you tell me another word for the universe?"),
+		},
+	}
+
+	serializedBytes, err := apijson.MarshalRoot(chatCompletionParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest("POST", "/prefix/openai/chat/completions", bytes.NewReader(serializedBytes))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replacementPath, err := getReplacementPathWithDeployment(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if replacementPath != "/prefix/openai/deployments/arbitraryDeployment/chat/completions" {
+		t.Fatalf("replacementpath didn't match: %s", replacementPath)
+	}
+}


### PR DESCRIPTION
## Summary
- allow Azure route matching by suffix
- add test for route matching with a prefix path
- refactor route matching helper into `pathMatchesRoute`

## Testing
- `go test ./...` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684e6f407cc48331abf4acf31b78c14c